### PR TITLE
backoff: tiny is not used anymore

### DIFF
--- a/backoff.go
+++ b/backoff.go
@@ -8,11 +8,9 @@ const (
 	LongMaxWait   = 40 * time.Minute
 	MediumMaxWait = 10 * time.Minute
 	ShortMaxWait  = 2 * time.Minute
-	TinyMaxWait   = 5 * time.Second
 )
 
 const (
 	LongMaxInterval  = 60 * time.Second
 	ShortMaxInterval = 5 * time.Second
-	TinyMaxInterval  = 1 * time.Second
 )


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/4449.

See https://github.com/giantswarm/apprclient/pull/21.