### PR TITLE
backoff: Interface -> BackOff ; don't expose cenkalti/backoff

### DIFF
--- a/constant.go
+++ b/constant.go
@@ -6,7 +6,7 @@ import (
 	"github.com/cenkalti/backoff"
 )
 
-func NewConstant(maxWait, maxInterval time.Duration) backoff.BackOff {
+func NewConstant(maxWait, maxInterval time.Duration) BackOff {
 	b := withMaxElapsedTime(backoff.NewConstantBackOff(maxInterval), maxWait)
 
 	b.Reset()
@@ -14,7 +14,7 @@ func NewConstant(maxWait, maxInterval time.Duration) backoff.BackOff {
 	return b
 }
 
-func withMaxElapsedTime(b backoff.BackOff, d time.Duration) *backOffMaxElapsedTime {
+func withMaxElapsedTime(b BackOff, d time.Duration) *backOffMaxElapsedTime {
 	return &backOffMaxElapsedTime{
 		underlying: b,
 		maxElapsed: d,
@@ -23,7 +23,7 @@ func withMaxElapsedTime(b backoff.BackOff, d time.Duration) *backOffMaxElapsedTi
 }
 
 type backOffMaxElapsedTime struct {
-	underlying backoff.BackOff
+	underlying BackOff
 	maxElapsed time.Duration
 	start      time.Time
 }

--- a/exponential.go
+++ b/exponential.go
@@ -6,7 +6,7 @@ import (
 	"github.com/cenkalti/backoff"
 )
 
-func NewExponential(maxWait, maxInterval time.Duration) backoff.BackOff {
+func NewExponential(maxWait, maxInterval time.Duration) Interface {
 	b := &backoff.ExponentialBackOff{
 		InitialInterval:     backoff.DefaultInitialInterval,
 		RandomizationFactor: backoff.DefaultRandomizationFactor,

--- a/exponential.go
+++ b/exponential.go
@@ -6,7 +6,7 @@ import (
 	"github.com/cenkalti/backoff"
 )
 
-func NewExponential(maxWait, maxInterval time.Duration) Interface {
+func NewExponential(maxWait, maxInterval time.Duration) BackOff {
 	b := &backoff.ExponentialBackOff{
 		InitialInterval:     backoff.DefaultInitialInterval,
 		RandomizationFactor: backoff.DefaultRandomizationFactor,

--- a/max_retries.go
+++ b/max_retries.go
@@ -6,7 +6,7 @@ import (
 	"github.com/cenkalti/backoff"
 )
 
-func NewMaxRetries(maxRetries uint64, maxInterval time.Duration) Interface {
+func NewMaxRetries(maxRetries uint64, maxInterval time.Duration) BackOff {
 	b := withMaxRetries(backoff.NewConstantBackOff(maxInterval), maxRetries)
 
 	b.Reset()
@@ -14,7 +14,7 @@ func NewMaxRetries(maxRetries uint64, maxInterval time.Duration) Interface {
 	return b
 }
 
-func withMaxRetries(b Interface, m uint64) *backOffMaxRetries {
+func withMaxRetries(b BackOff, m uint64) *backOffMaxRetries {
 	return &backOffMaxRetries{
 		maxRetries: m,
 		retryCount: 0,
@@ -25,7 +25,7 @@ func withMaxRetries(b Interface, m uint64) *backOffMaxRetries {
 type backOffMaxRetries struct {
 	maxRetries uint64
 	retryCount uint64
-	underlying Interface
+	underlying BackOff
 }
 
 func (b *backOffMaxRetries) NextBackOff() time.Duration {

--- a/max_retries.go
+++ b/max_retries.go
@@ -14,7 +14,7 @@ func NewMaxRetries(maxRetries uint64, maxInterval time.Duration) Interface {
 	return b
 }
 
-func withMaxRetries(b backoff.BackOff, m uint64) *backOffMaxRetries {
+func withMaxRetries(b Interface, m uint64) *backOffMaxRetries {
 	return &backOffMaxRetries{
 		maxRetries: m,
 		retryCount: 0,
@@ -25,7 +25,7 @@ func withMaxRetries(b backoff.BackOff, m uint64) *backOffMaxRetries {
 type backOffMaxRetries struct {
 	maxRetries uint64
 	retryCount uint64
-	underlying backoff.BackOff
+	underlying Interface
 }
 
 func (b *backOffMaxRetries) NextBackOff() time.Duration {

--- a/notify.go
+++ b/notify.go
@@ -1,0 +1,20 @@
+package backoff
+
+import (
+	"time"
+
+	"github.com/cenkalti/backoff"
+)
+
+// Notify is a notify-on-error function. It receives an operation error and
+// backoff delay if the operation failed (with an error).
+//
+// NOTE that if the backoff policy stated to stop retrying, the notify function
+// isn't called.
+type Notify func(error, time.Duration)
+
+func (n Notify) toCenkalti() backoff.Notify {
+	var f func(error, time.Duration)
+	f = n
+	return f
+}

--- a/operation.go
+++ b/operation.go
@@ -1,0 +1,13 @@
+package backoff
+
+import "github.com/cenkalti/backoff"
+
+// An Operation is executing by Retry() or RetryNotify().
+// The operation will be retried using a backoff policy if it returns an error.
+type Operation func() error
+
+func (o Operation) toCenkalti() backoff.Operation {
+	var f func() error
+	f = o
+	return f
+}

--- a/permanent.go
+++ b/permanent.go
@@ -1,5 +1,9 @@
 package backoff
 
-import "github.com/cenkalti/backoff"
+import (
+	"github.com/cenkalti/backoff"
+)
 
-var Permanent = backoff.Permanent
+func Permanent(err error) error {
+	return backoff.Permanent(err)
+}

--- a/retry.go
+++ b/retry.go
@@ -1,7 +1,27 @@
 package backoff
 
-import "github.com/cenkalti/backoff"
+import (
+	"github.com/cenkalti/backoff"
+	"github.com/giantswarm/microerror"
+)
 
-var Retry = backoff.Retry
+// Retry retries the operation o until it does not return error or BackOff
+// stops. See https://godoc.org/github.com/cenkalti/backoff#Retry for details.
+func Retry(o Operation, b BackOff) error {
+	err := backoff.Retry(o.toCenkalti(), b)
+	if err != nil {
+		return microerror.Mask(err)
+	}
 
-var RetryNotify = backoff.RetryNotify
+	return nil
+}
+
+// RetryNotify does what Retry do with notification between each try.
+func RetryNotify(o Operation, b BackOff, n Notify) error {
+	err := backoff.RetryNotify(o.toCenkalti(), b, n.toCenkalti())
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}

--- a/spec.go
+++ b/spec.go
@@ -2,9 +2,12 @@ package backoff
 
 import "time"
 
-// Interface describes how a backoff has to be implemented. Also see
+// BackOff describes how a backoff has to be implemented. Also see
 // https://godoc.org/github.com/cenkalti/backoff#BackOff.
-type Interface interface {
+type BackOff interface {
 	NextBackOff() time.Duration
 	Reset()
 }
+
+// Interface is an alias for backward compatibility.
+type Interface = BackOff

--- a/spec_test.go
+++ b/spec_test.go
@@ -1,0 +1,16 @@
+package backoff
+
+import (
+	"testing"
+
+	"github.com/cenkalti/backoff"
+)
+
+// Test_Interface tests if this library and underlying implementation
+// interfaces are compatible.
+func Test_Interface(t *testing.T) {
+	var custom BackOff
+	var underlying backoff.BackOff
+	custom = underlying
+	underlying = custom
+}

--- a/spec_test.go
+++ b/spec_test.go
@@ -6,9 +6,9 @@ import (
 	"github.com/cenkalti/backoff"
 )
 
-// Test_Interface tests if this library and underlying implementation
+// Test_BackOff tests if this library and underlying implementation
 // interfaces are compatible.
-func Test_Interface(t *testing.T) {
+func Test_BackOff(t *testing.T) {
 	var custom BackOff
 	var underlying backoff.BackOff
 	custom = underlying

--- a/stop.go
+++ b/stop.go
@@ -2,4 +2,4 @@ package backoff
 
 import "github.com/cenkalti/backoff"
 
-var Stop = backoff.Stop
+const Stop = backoff.Stop


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/6844

Some refactorings I need for `opsctl deploy`:

- `b Interface` isn't very intuitive. `b BackOff` is more descriptive.
- There is a type alias so the thing is backward compatible.
- Sometimes it's useful to memorize types in the using code. External
  `cenkalti` library shouldn't be exposed when doing that. That binds us
  to this concrete implementation.