### PR TITLE
Fix error matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Permanent backoff works with Golang error matching functions.
 
+### Changed
+- Bump github.com/celkati/backoff dependency from v2.2.1 to v4.0.2.
 
 ## [0.2.0] 2020-03-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Permanent backoff works with Golang error matching functions.
 
 ### Changed
-- Bump github.com/celkati/backoff dependency from v2.2.1 to v4.0.2.
+- Bump github.com/cenkalti/backoff dependency from v2.2.1 to v4.0.2.
 
 ## [0.2.0] 2020-03-20
 

--- a/constant.go
+++ b/constant.go
@@ -3,7 +3,7 @@ package backoff
 import (
 	"time"
 
-	"github.com/cenkalti/backoff"
+	"github.com/cenkalti/backoff/v4"
 )
 
 func NewConstant(maxWait, maxInterval time.Duration) BackOff {

--- a/exponential.go
+++ b/exponential.go
@@ -3,7 +3,7 @@ package backoff
 import (
 	"time"
 
-	"github.com/cenkalti/backoff"
+	"github.com/cenkalti/backoff/v4"
 )
 
 func NewExponential(maxWait, maxInterval time.Duration) BackOff {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/giantswarm/backoff
 go 1.13
 
 require (
-	github.com/cenkalti/backoff v2.2.1+incompatible
+	github.com/cenkalti/backoff/v4 v4.0.2
 	github.com/giantswarm/microerror v0.2.0
 	github.com/giantswarm/micrologger v0.3.1
 )

--- a/go.sum
+++ b/go.sum
@@ -24,7 +24,6 @@ github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+Ce
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
-github.com/cenkalti/backoff v1.1.0 h1:QnvVp8ikKCDWOsFheytRCoYWYPO/ObCTBGxT19Hc+yE=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff/v4 v4.0.2 h1:JIufpQLbh4DkbQoii76ItQIUFzevQSqOLZca4eamEDs=

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,11 @@ github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+Ce
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
+github.com/cenkalti/backoff v1.1.0 h1:QnvVp8ikKCDWOsFheytRCoYWYPO/ObCTBGxT19Hc+yE=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
+github.com/cenkalti/backoff/v4 v4.0.2 h1:JIufpQLbh4DkbQoii76ItQIUFzevQSqOLZca4eamEDs=
+github.com/cenkalti/backoff/v4 v4.0.2/go.mod h1:eEew/i+1Q6OrCDZh3WiXYv3+nJwBASZ8Bog/87DQnVg=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/clbanning/x2j v0.0.0-20191024224557-825249438eec/go.mod h1:jMjuTZXRI4dUb/I5gc9Hdhagfvm9+RyrPryS/auMzxE=

--- a/matching_test.go
+++ b/matching_test.go
@@ -1,0 +1,36 @@
+package backoff
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+var (
+	customError    = fmt.Errorf("custom error")
+	differentError = fmt.Errorf("different error")
+)
+
+func Test_ErrorMatching(t *testing.T) {
+	// sanity check
+	err1 := customError
+	if !errors.Is(err1, customError) {
+		t.Fatalf("expected %v to match %T", err1, customError)
+	}
+
+	err2 := differentError
+	if !errors.Is(err2, differentError) {
+		t.Fatalf("expected %v to match %T", err2, differentError)
+	}
+
+	// actual test
+	permanentErr1 := Permanent(err1)
+	if !errors.Is(permanentErr1, customError) {
+		t.Fatalf("expected %v to match %T", permanentErr1, customError)
+	}
+
+	permanentErr2 := Permanent(err2)
+	if !errors.Is(permanentErr2, differentError) {
+		t.Fatalf("expected %v to match %T", permanentErr2, differentError)
+	}
+}

--- a/matching_test.go
+++ b/matching_test.go
@@ -2,13 +2,12 @@ package backoff
 
 import (
 	"errors"
-	"fmt"
 	"testing"
 )
 
 var (
-	customError    = fmt.Errorf("custom error")
-	differentError = fmt.Errorf("different error")
+	customError    = errors.New("custom error")
+	differentError = errors.New("different error")
 
 	tests = map[error]error{
 		// sanity check
@@ -23,7 +22,10 @@ var (
 func Test_ErrorMatching(t *testing.T) {
 	for err, expectedType := range tests {
 		if !errors.Is(err, expectedType) {
-			t.Fatalf("expected %v to match %T", err, expectedType)
+			t.Fatalf("errors.Is: expected %v to match %T", err, expectedType)
+		}
+		if !errors.As(err, &expectedType) {
+			t.Fatalf("errors.As: expected %v to match %T", err, expectedType)
 		}
 	}
 }

--- a/matching_test.go
+++ b/matching_test.go
@@ -9,28 +9,21 @@ import (
 var (
 	customError    = fmt.Errorf("custom error")
 	differentError = fmt.Errorf("different error")
+
+	tests = map[error]error{
+		// sanity check
+		customError:    customError,
+		differentError: differentError,
+		// actual test
+		Permanent(customError):    customError,
+		Permanent(differentError): differentError,
+	}
 )
 
 func Test_ErrorMatching(t *testing.T) {
-	// sanity check
-	err1 := customError
-	if !errors.Is(err1, customError) {
-		t.Fatalf("expected %v to match %T", err1, customError)
-	}
-
-	err2 := differentError
-	if !errors.Is(err2, differentError) {
-		t.Fatalf("expected %v to match %T", err2, differentError)
-	}
-
-	// actual test
-	permanentErr1 := Permanent(err1)
-	if !errors.Is(permanentErr1, customError) {
-		t.Fatalf("expected %v to match %T", permanentErr1, customError)
-	}
-
-	permanentErr2 := Permanent(err2)
-	if !errors.Is(permanentErr2, differentError) {
-		t.Fatalf("expected %v to match %T", permanentErr2, differentError)
+	for err, expectedType := range tests {
+		if !errors.Is(err, expectedType) {
+			t.Fatalf("expected %v to match %T", err, expectedType)
+		}
 	}
 }

--- a/max_retries.go
+++ b/max_retries.go
@@ -3,7 +3,7 @@ package backoff
 import (
 	"time"
 
-	"github.com/cenkalti/backoff"
+	"github.com/cenkalti/backoff/v4"
 )
 
 func NewMaxRetries(maxRetries uint64, maxInterval time.Duration) BackOff {

--- a/permanent.go
+++ b/permanent.go
@@ -1,7 +1,7 @@
 package backoff
 
 import (
-	"github.com/cenkalti/backoff"
+	"github.com/cenkalti/backoff/v4"
 )
 
 func Permanent(err error) error {

--- a/retry.go
+++ b/retry.go
@@ -1,7 +1,7 @@
 package backoff
 
 import (
-	"github.com/cenkalti/backoff"
+	"github.com/cenkalti/backoff/v4"
 	"github.com/giantswarm/microerror"
 )
 

--- a/spec.go
+++ b/spec.go
@@ -3,7 +3,7 @@ package backoff
 import "time"
 
 // BackOff describes how a backoff has to be implemented. Also see
-// https://godoc.org/github.com/cenkalti/backoff#BackOff.
+// https://godoc.org/github.com/cenkalti/backoff/v4#BackOff.
 type BackOff interface {
 	NextBackOff() time.Duration
 	Reset()

--- a/spec_test.go
+++ b/spec_test.go
@@ -3,7 +3,7 @@ package backoff
 import (
 	"testing"
 
-	"github.com/cenkalti/backoff"
+	"github.com/cenkalti/backoff/v4"
 )
 
 // Test_BackOff tests if this library and underlying implementation interfaces

--- a/stop.go
+++ b/stop.go
@@ -3,7 +3,7 @@ package backoff
 import (
 	"time"
 
-	"github.com/cenkalti/backoff"
+	"github.com/cenkalti/backoff/v4"
 )
 
 const Stop = backoff.Stop


### PR DESCRIPTION
`backoff.Permanent(err)` now works with Golang's default error matching method: `errors.Is/As`. This will enable us to truly deprecate `microerror.Cause` in the future. More details in the issue.

Fixes https://github.com/giantswarm/giantswarm/issues/10503


## Checklist
- [x] Update changelog in CHANGELOG.md.

## Example
https://play.golang.org/p/kEB8Hu2uXSC
```go
package main

import (
	"errors"
	"fmt"

	"github.com/giantswarm/backoff"
	"github.com/giantswarm/microerror"
)

var customError = &microerror.Error{
	Kind: "customError",
}

func IsCustom(err error) bool {
	return errors.Is(err, customError)
}

func main() {
	original := customError
	masked := microerror.Mask(customError)
	permanent := backoff.Permanent(customError)

	if IsCustom(original) {
		fmt.Println("Works for original")
	}

	if IsCustom(masked) {
		fmt.Println("Works for masked")
	}

	if IsCustom(permanent) { // this check failed before
		fmt.Println("Works for permanent")
	}
}
-- go.mod --
module play.ground

require (
	github.com/giantswarm/microerror v0.2.0
	github.com/giantswarm/backoff v0.2.1-0.20200430090656-e73f116f2ce0
)
```

Result
```
Works for original
Works for masked
Works for permanent

Program exited.
```